### PR TITLE
[MPOM-270] Fix enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1115,6 +1115,22 @@ under the License.
               <version>1.4</version>
             </dependency>
           </dependencies>
+          <executions>
+            <execution>
+              <id>enforce-bytecode-version</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <enforceBytecodeVersion>
+                    <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
+                  </enforceBytecodeVersion>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -1134,22 +1150,6 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-bytecode-version</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <enforceBytecodeVersion>
-                  <maxJdkVersion>${maven.compiler.target}</maxJdkVersion>
-                </enforceBytecodeVersion>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>


### PR DESCRIPTION
Enforcer as is causes that downstream in case of update
POM must completely redefine plugin, thus, loosing all
the benefits of parent POM pluginMgmt.

Move plugin definition to pluginMgmt instead to fully
define it and it's dependines in plugin section. Keep
execution in plugin section.

Update to latest enforcer as well.

------

See for example https://github.com/apache/maven-resolver/pull/129