### PR TITLE
[MPOM-272] Fix TLP depMgmt, drop legacy from doxia parent

### DIFF
--- a/doxia-tools/pom.xml
+++ b/doxia-tools/pom.xml
@@ -59,22 +59,6 @@ under the License.
     <maven.site.path>doxia-tools-archives/${project.artifactId}-LATEST</maven.site.path>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- Plexus -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-container-default</artifactId>
-        <version>2.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.3.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -913,6 +913,7 @@ under the License.
     <maven.site.cache>${user.home}/maven-sites</maven.site.cache>
     <maven.site.path>../..</maven.site.path><!-- to be overridden -->
     <mavenPluginToolsVersion>3.6.1</mavenPluginToolsVersion>
+    <sisuVersion>0.3.5</sisuVersion>
     <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some) -->
     <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength</checkstyle.violation.ignore>
     <project.build.outputTimestamp>2020-01-26T09:04:18Z</project.build.outputTimestamp>
@@ -920,6 +921,23 @@ under the License.
 
   <dependencyManagement>
     <dependencies>
+      <!-- Plexus Shim -->
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.inject</artifactId>
+        <version>${sisuVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>org.eclipse.sisu.plexus</artifactId>
+        <version>${sisuVersion}</version>
+      </dependency>
+      <!-- Commonly shared: last Java7 -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.3.0</version>
+      </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-annotations</artifactId>


### PR DESCRIPTION
Remove legacy from doxia parent (plexus shim is "drop in"
replacement), and define useful stuff at TLP the
p-u, plexus shim as well as downstream
these are most probably used, is easier
to align along these.