### PR TITLE
[MPOM-349] Apply spotless to check/reformat code + poms

### DIFF
--- a/apache-resource-bundles/pom.xml
+++ b/apache-resource-bundles/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -42,8 +40,8 @@
   </issueManagement>
 
   <ciManagement>
-    <url>https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-project-resources/</url>
     <system>Jenkins</system>
+    <url>https://ci-builds.apache.org/job/Maven/job/maven-box/job/maven-project-resources/</url>
   </ciManagement>
 
   <!-- There is no distributionManagement for this project. The site is a part of the main Maven site. -->
@@ -62,9 +60,9 @@
             <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
             <versionPrefix>${project.artifactId}-</versionPrefix>
             <!-- Used by announcement-generate goal -->
-<!-- TODO Which template should we use for Apache Resource Bundles?            
+            <!-- TODO Which template should we use for Apache Resource Bundles?            
             <templateDirectory>org/apache/maven/shared</templateDirectory>
--->
+            -->
             <!-- Used by announcement-mail goal -->
             <subject>[ANN] ${project.name} ${project.version} Released</subject>
             <toAddresses>
@@ -81,21 +79,21 @@
           </configuration>
           <dependencies>
             <!-- Used by announcement-generate goal -->
-<!-- Uncomment this when we have decided which template to use
+            <!-- Uncomment this when we have decided which template to use
             <dependency>
               <groupId>org.apache.maven.shared</groupId>
               <artifactId>maven-shared-resources</artifactId>
               <version>1</version>
             </dependency>
--->
+            -->
           </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <!-- Turn this into a lifecycle -->
-      <plugin>      
-        <artifactId>maven-remote-resources-plugin</artifactId>        
+      <plugin>
+        <artifactId>maven-remote-resources-plugin</artifactId>
         <executions>
           <execution>
             <goals>

--- a/doxia-tools/pom.xml
+++ b/doxia-tools/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -67,7 +65,8 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <configuration>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
           </configuration>
         </plugin>
       </plugins>
@@ -77,15 +76,17 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
-          <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+          <!-- no need for site:stage, use target/site -->
+          <content>${project.reporting.outputDirectory}</content>
         </configuration>
         <executions>
           <execution>
+            <!-- deploy site with maven-scm-publish-plugin -->
             <id>scm-publish</id>
-            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
             <goals>
               <goal>publish-scm</goal>
             </goals>
+            <phase>site-deploy</phase>
           </execution>
         </executions>
       </plugin>

--- a/maven-extensions/pom.xml
+++ b/maven-extensions/pom.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -95,22 +94,25 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <configuration>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
+            <!-- don't deploy site with maven-site-plugin -->
           </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-scm-publish-plugin</artifactId>
           <configuration>
-            <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+            <!-- no need for site:stage, use target/site -->
+            <content>${project.reporting.outputDirectory}</content>
           </configuration>
           <executions>
             <execution>
+              <!-- deploy site with maven-scm-publish-plugin -->
               <id>scm-publish</id>
-              <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
               <goals>
                 <goal>publish-scm</goal>
               </goals>
+              <phase>site-deploy</phase>
             </execution>
           </executions>
         </plugin>
@@ -122,10 +124,10 @@ under the License.
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
+            <id>ensure-no-container-api</id>
             <goals>
               <goal>enforce</goal>
             </goals>
-            <id>ensure-no-container-api</id>
             <configuration>
               <rules>
                 <bannedDependencies>
@@ -160,10 +162,10 @@ under the License.
             <executions>
               <execution>
                 <id>docck-check</id>
-                <phase>verify</phase>
                 <goals>
                   <goal>check</goal>
                 </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -17,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -124,7 +123,8 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <configuration>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
           </configuration>
         </plugin>
       </plugins>
@@ -138,15 +138,17 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
-          <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+          <!-- no need for site:stage, use target/site -->
+          <content>${project.reporting.outputDirectory}</content>
         </configuration>
         <executions>
           <execution>
+            <!-- deploy site with maven-scm-publish-plugin -->
             <id>scm-publish</id>
-            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
             <goals>
               <goal>publish-scm</goal>
             </goals>
+            <phase>site-deploy</phase>
           </execution>
         </executions>
       </plugin>
@@ -155,10 +157,10 @@ under the License.
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
+            <id>ensure-no-container-api</id>
             <goals>
               <goal>enforce</goal>
             </goals>
-            <id>ensure-no-container-api</id>
             <configuration>
               <rules>
                 <bannedDependencies>
@@ -202,10 +204,10 @@ under the License.
             <executions>
               <execution>
                 <id>docck-check</id>
-                <phase>verify</phase>
                 <goals>
                   <goal>check</goal>
                 </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>

--- a/maven-shared-components/pom.xml
+++ b/maven-shared-components/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -98,7 +96,8 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <configuration>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
           </configuration>
         </plugin>
       </plugins>
@@ -108,15 +107,17 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
-          <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+          <!-- no need for site:stage, use target/site -->
+          <content>${project.reporting.outputDirectory}</content>
         </configuration>
         <executions>
           <execution>
+            <!-- deploy site with maven-scm-publish-plugin -->
             <id>scm-publish</id>
-            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
             <goals>
               <goal>publish-scm</goal>
             </goals>
+            <phase>site-deploy</phase>
           </execution>
         </executions>
       </plugin>

--- a/maven-skins/pom.xml
+++ b/maven-skins/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -71,7 +69,8 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <configuration>
-            <skipDeploy>true</skipDeploy><!-- don't deploy site with maven-site-plugin -->
+            <!-- don't deploy site with maven-site-plugin -->
+            <skipDeploy>true</skipDeploy>
           </configuration>
         </plugin>
       </plugins>
@@ -81,15 +80,17 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
-          <content>${project.reporting.outputDirectory}</content><!-- no need for site:stage, use target/site -->
+          <!-- no need for site:stage, use target/site -->
+          <content>${project.reporting.outputDirectory}</content>
         </configuration>
         <executions>
           <execution>
+            <!-- deploy site with maven-scm-publish-plugin -->
             <id>scm-publish</id>
-            <phase>site-deploy</phase><!-- deploy site with maven-scm-publish-plugin -->
             <goals>
               <goal>publish-scm</goal>
             </goals>
+            <phase>site-deploy</phase>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -944,8 +944,12 @@ under the License.
     <sisuVersion>0.3.5</sisuVersion>
     <fluidoSkinVersion>1.11.1</fluidoSkinVersion>
     <surefire.version>3.0.0-M7</surefire.version><!-- for surefire, failsafe and surefire-report -->
-    <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some) -->
-    <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength</checkstyle.violation.ignore>
+    <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some)
+         and those that are enforced by the formatting checks from spotless -->
+    <checkstyle.violation.spotless.ignore>LineLength,RegexpHeader,LeftCurly,RightCurly,OperatorWrap,ParentPad,
+      WhitespaceAfter,WhitespaceAround,GenericWhitespace</checkstyle.violation.spotless.ignore>
+    <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength,
+      ${checkstyle.violation.spotless.ignore}</checkstyle.violation.ignore>
     <project.build.outputTimestamp>2022-07-20T17:09:29Z</project.build.outputTimestamp>
   </properties>
 
@@ -1170,9 +1174,53 @@ under the License.
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.27.1</version>
+          <configuration>
+            <java>
+              <importOrder>
+                <file>config/maven-eclipse-importorder.txt</file>
+              </importOrder>
+              <removeUnusedImports/>
+              <palantirJavaFormat/>
+              <licenseHeader>
+                <file>config/maven-header-plain.txt</file>
+              </licenseHeader>
+            </java>
+            <pom>
+              <sortPom>
+                <expandEmptyElements>false</expandEmptyElements>
+              </sortPom>
+            </pom>
+            <upToDateChecking>
+              <enabled>true</enabled>
+            </upToDateChecking>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.shared</groupId>
+              <artifactId>maven-shared-resources</artifactId>
+              <version>5-SNAPSHOT</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <execution>
+              <goals>
+                <goal>${spotless.action}</goal>
+              </goals>
+              <phase>process-sources</phase>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -1245,6 +1293,28 @@ under the License.
   </reporting>
 
   <profiles>
+    <profile>
+      <id>format-check</id>
+      <activation>
+        <property>
+          <name>!format</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>check</spotless.action>
+      </properties>
+    </profile>
+    <profile>
+      <id>format</id>
+      <activation>
+        <property>
+          <name>format</name>
+        </property>
+      </activation>
+      <properties>
+        <spotless.action>apply</spotless.action>
+      </properties>
+    </profile>
     <profile>
       <!-- "utility" profile allowing all downstream projects to prepare for upcoming bans: drop legacy -->
       <id>drop-legacy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1055,7 +1055,7 @@ under the License.
             <dependency>
               <groupId>org.apache.maven.shared</groupId>
               <artifactId>maven-shared-resources</artifactId>
-              <version>4</version>
+              <version>5</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -946,7 +946,7 @@ under the License.
     <surefire.version>3.0.0-M7</surefire.version>
     <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some)
          and those that are enforced by the formatting checks from spotless -->
-    <checkstyle.violation.spotless.ignore>LineLength,RegexpHeader,LeftCurly,RightCurly,OperatorWrap,ParentPad,
+    <checkstyle.violation.spotless.ignore>LineLength,RegexpHeader,LeftCurly,RightCurly,OperatorWrap,ParenPad,
       WhitespaceAfter,WhitespaceAround,GenericWhitespace</checkstyle.violation.spotless.ignore>
     <checkstyle.violation.ignore>RedundantThrows,NewlineAtEndOfFile,ParameterNumber,MethodLength,FileLength,
       ${checkstyle.violation.spotless.ignore}</checkstyle.violation.ignore>

--- a/pom.xml
+++ b/pom.xml
@@ -1203,7 +1203,7 @@ under the License.
             <dependency>
               <groupId>org.apache.maven.shared</groupId>
               <artifactId>maven-shared-resources</artifactId>
-              <version>5-SNAPSHOT</version>
+              <version>5</version>
             </dependency>
           </dependencies>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -18,7 +17,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -104,10 +102,10 @@ under the License.
       <id>cstamas</id>
       <name>Tamas Cservenak</name>
       <email>cstamas@apache.org</email>
-      <timezone>+1</timezone>
       <roles>
         <role>PMC Member</role>
       </roles>
+      <timezone>+1</timezone>
     </developer>
     <developer>
       <id>dennisl</id>
@@ -228,10 +226,10 @@ under the License.
       <name>Ralph Goers</name>
       <email>rgoers@apache.org</email>
       <organization>Intuit</organization>
-      <timezone>-8</timezone>
       <roles>
         <role>PMC Member</role>
       </roles>
+      <timezone>-8</timezone>
     </developer>
     <developer>
       <id>sjaranowski</id>
@@ -294,20 +292,20 @@ under the License.
       <id>adangel</id>
       <name>Andreas Dangel</name>
       <email>adangel@apache.org</email>
-      <timezone>Europe/Berlin</timezone>
       <roles>
         <role>Committer</role>
       </roles>
+      <timezone>Europe/Berlin</timezone>
     </developer>
     <developer>
       <id>bdemers</id>
       <name>Brian Demers</name>
-      <organization>Sonatype</organization>
       <email>bdemers@apache.org</email>
-      <timezone>-5</timezone>
+      <organization>Sonatype</organization>
       <roles>
         <role>Committer</role>
       </roles>
+      <timezone>-5</timezone>
     </developer>
     <developer>
       <id>bellingard</id>
@@ -339,20 +337,20 @@ under the License.
       <id>dantran</id>
       <name>Dan Tran</name>
       <email>dantran@apache.org</email>
-      <timezone>-8</timezone>      
       <roles>
         <role>Committer</role>
       </roles>
+      <timezone>-8</timezone>
     </developer>
     <developer>
       <id>dbradicich</id>
       <name>Damian Bradicich</name>
-      <organization>Sonatype</organization>
       <email>dbradicich@apache.org</email>
-      <timezone>-5</timezone>
+      <organization>Sonatype</organization>
       <roles>
         <role>Committer</role>
       </roles>
+      <timezone>-5</timezone>
     </developer>
     <developer>
       <id>brett</id>
@@ -406,8 +404,8 @@ under the License.
     <developer>
       <id>godin</id>
       <name>Evgeny Mandrikov</name>
-      <organization>SonarSource</organization>
       <email>godin@apache.org</email>
+      <organization>SonarSource</organization>
       <roles>
         <role>Committer</role>
       </roles>
@@ -430,7 +428,7 @@ under the License.
         <role>Committer</role>
       </roles>
       <timezone>Europe/Zurich</timezone>
-    </developer>     
+    </developer>
     <developer>
       <id>jjensen</id>
       <name>Jeff Jensen</name>
@@ -878,9 +876,9 @@ under the License.
     </mailingList>
     <mailingList>
       <name>Maven Announcements List</name>
-      <post>announce@maven.apache.org</post>
       <subscribe>mailto:announce-subscribe@maven.apache.org</subscribe>
       <unsubscribe>mailto:announce-unsubscribe@maven.apache.org</unsubscribe>
+      <post>announce@maven.apache.org</post>
       <archive>https://lists.apache.org/list.html?announce@maven.apache.org</archive>
       <otherArchives>
         <otherArchive>https://mail-archives.apache.org/mod_mbox/maven-announce/</otherArchive>
@@ -911,8 +909,8 @@ under the License.
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-parent.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-parent.git</developerConnection>
-    <url>https://github.com/apache/maven-parent/tree/${project.scm.tag}</url>
     <tag>HEAD</tag>
+    <url>https://github.com/apache/maven-parent/tree/${project.scm.tag}</url>
   </scm>
 
   <ciManagement>
@@ -937,13 +935,15 @@ under the License.
   <properties>
     <javaVersion>7</javaVersion>
     <maven.compiler.source>1.${javaVersion}</maven.compiler.source>
-    <maven.compiler.target>1.${javaVersion}</maven.compiler.target>    
+    <maven.compiler.target>1.${javaVersion}</maven.compiler.target>
     <sonar.host.url>https://builds.apache.org/analysis/</sonar.host.url>
     <maven.site.cache>${user.home}/maven-sites</maven.site.cache>
-    <maven.site.path>../..</maven.site.path><!-- to be overridden -->
+    <!-- to be overridden -->
+    <maven.site.path>../..</maven.site.path>
     <sisuVersion>0.3.5</sisuVersion>
     <fluidoSkinVersion>1.11.1</fluidoSkinVersion>
-    <surefire.version>3.0.0-M7</surefire.version><!-- for surefire, failsafe and surefire-report -->
+    <!-- for surefire, failsafe and surefire-report -->
+    <surefire.version>3.0.0-M7</surefire.version>
     <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some)
          and those that are enforced by the formatting checks from spotless -->
     <checkstyle.violation.spotless.ignore>LineLength,RegexpHeader,LeftCurly,RightCurly,OperatorWrap,ParentPad,
@@ -981,13 +981,14 @@ under the License.
   </dependencyManagement>
 
   <repositories>
-    <repository><!-- useful to resolve parent pom when it is a SNAPSHOT -->
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>https://repository.apache.org/snapshots</url>
+    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
+    <repository>
       <releases>
         <enabled>false</enabled>
       </releases>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/snapshots</url>
     </repository>
   </repositories>
 
@@ -1227,10 +1228,10 @@ under the License.
         <executions>
           <execution>
             <id>checkstyle-check</id>
-            <phase>validate</phase>
             <goals>
               <goal>check</goal>
             </goals>
+            <phase>validate</phase>
           </execution>
         </executions>
       </plugin>
@@ -1243,11 +1244,15 @@ under the License.
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes combine.children="append">
-            <exclude>.repository/**</exclude><!-- Jenkins job with local Maven repository -->
-            <exclude>.maven/spy.log</exclude><!-- Hudson Maven3 integration log -->
-            <exclude>dependency-reduced-pom.xml</exclude><!-- Maven shade plugin -->
-            <exclude>.asf.yaml</exclude><!-- GitHub Support -->
             <exclude>.java-version</exclude>
+            <!-- Jenkins job with local Maven repository -->
+            <exclude>.repository/**</exclude>
+            <!-- Hudson Maven3 integration log -->
+            <exclude>.maven/spy.log</exclude>
+            <!-- Maven shade plugin -->
+            <exclude>dependency-reduced-pom.xml</exclude>
+            <!-- GitHub Support -->
+            <exclude>.asf.yaml</exclude>
           </excludes>
         </configuration>
         <executions>
@@ -1409,10 +1414,10 @@ under the License.
             <executions>
               <execution>
                 <id>cpd-check</id>
-                <phase>verify</phase>
                 <goals>
                   <goal>cpd-check</goal>
                 </goals>
+                <phase>verify</phase>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MPOM-349

- [MPOM-349] Apply spotless to check/reformat code + poms
- [MPOM-349] Reformat poms

Depends on https://github.com/apache/maven-shared-resources/pull/5

Discussed on
 * https://lists.apache.org/thread/ok9qdl1w92f9fhdkz3tmc5f65ytpppqpD
 * https://lists.apache.org/thread/md6do2dllt9cv4s311y3ky6245xmvd0w

The PR includes the following changes:
 * add spotless with palantir formatter (120 column, 4 spaces indent) + pom formatter (2 spaces indent + pom ordering)
 * disable checkstyle rules enforced by the formatter
 * enable formatter check (code style validation) by default
 * provide a format profile (activated with the format property) to apply formatting rules automatically
 * reformat poms to pass the new checks (in a subsequent commit to ease review)

