### PR TITLE
[MPOM-376] Spotless importOrder should be taken into consideration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1166,11 +1166,13 @@ under the License.
           <version>2.27.1</version>
           <configuration>
             <java>
+              <!-- orders of used formatters are important MPOM-376 -->
+              <!-- eg. palantir override importOrder, so should be first -->
+              <palantirJavaFormat/>
+              <removeUnusedImports/>
               <importOrder>
                 <file>config/maven-eclipse-importorder.txt</file>
               </importOrder>
-              <removeUnusedImports/>
-              <palantirJavaFormat/>
               <licenseHeader>
                 <file>config/maven-header-plain.txt</file>
               </licenseHeader>


### PR DESCRIPTION
Spotless formatters must be placed in correct order in configuration