### PR TITLE
[MPOM-346] publish SBOM on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -909,7 +909,7 @@ under the License.
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/maven-parent.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-parent.git</developerConnection>
-    <tag>maven-parent-38</tag>
+    <tag>master</tag>
     <url>https://github.com/apache/maven-parent/tree/${project.scm.tag}</url>
   </scm>
 
@@ -1207,6 +1207,7 @@ under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
@@ -1290,6 +1291,26 @@ under the License.
   </reporting>
 
   <profiles>
+    <profile>
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>2.7.4</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>makeAggregateBom</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>format-check</id>
       <activation>


### PR DESCRIPTION
see https://cwiki.apache.org/confluence/display/COMDEV/SBOM

with https://github.com/CycloneDX/cyclonedx-maven-plugin/pull/242 fixed in `cyclonedx-maven-plugin` 2.7.4, using `makeAggregateBom` can be used everywhere