### PR TITLE
[MPOM-346] Do not run ITs in release

### DIFF
--- a/maven-extensions/pom.xml
+++ b/maven-extensions/pom.xml
@@ -53,7 +53,7 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <releaseProfiles>apache-release,run-its</releaseProfiles>
+            <releaseProfiles>apache-release</releaseProfiles>
           </configuration>
         </plugin>
         <!-- publish mono-module site with "mvn site-deploy" -->

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -66,7 +66,7 @@ under the License.
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <releaseProfiles>apache-release,run-its</releaseProfiles>
+            <releaseProfiles>apache-release</releaseProfiles>
           </configuration>
         </plugin>
         <plugin>

--- a/maven-skins/pom.xml
+++ b/maven-skins/pom.xml
@@ -61,7 +61,7 @@ under the License.
         <plugin>
           <artifactId>maven-release-plugin</artifactId>
           <configuration>
-            <releaseProfiles>apache-release,run-its</releaseProfiles>
+            <releaseProfiles>apache-release</releaseProfiles>
           </configuration>
         </plugin>
         <!-- publish mono-module site with "mvn site-deploy" -->


### PR DESCRIPTION
As it makes no sense. As I did release m-install-p and m-deploy-p, at my amazement the release:prepare did end quickly (OK), while release:perform started to run ITs? What is the rationale here, after things were tagged? It really does not gives anything, but takes precious time. If relMgr is not cautious enough to ensure ITs are OK beforehand doing the release, that's it, a new release will happen.

But running ITs in ANY of the release mojo makes no sense.

Personally, I'd simply not run any kind of tests in any of two release Mojos, as it makes no sense, but in turn, makes release that is already too fragile, even more problematic and time consuming. 

If missed by relMgr, and a new version will happen, so what?

---

https://issues.apache.org/jira/browse/MPOM-397