### PR TITLE
[MPOM-427] use version.artifactId property for dependency versions (like plugins)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -940,10 +940,10 @@ under the License.
     <!-- to be overridden -->
     <maven.site.path>../..</maven.site.path>
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
-    <sisuVersion>0.9.0.M2</sisuVersion>
-    <plexusUtilsVersion>4.0.0</plexusUtilsVersion>
-    <plexusXmlVersion>4.0.0</plexusXmlVersion>
-    <fluidoSkinVersion>1.11.2</fluidoSkinVersion>
+    <version.sisu-maven-plugin>0.9.0.M2</version.sisu-maven-plugin>
+    <version.plexus-utils>4.0.0</version.plexus-utils>
+    <version.plexus-xml>4.0.0</version.plexus-xml>
+    <version.maven-fluido-skin>1.11.2</version.maven-fluido-skin>
     <!-- don't fail check for some rules that are too hard to enforce (could even be told broken for some)
          and those that are enforced by the formatting checks from spotless -->
     <checkstyle.violation.ignore>ParameterNumber,MethodLength,FileLength</checkstyle.violation.ignore>
@@ -956,22 +956,22 @@ under the License.
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
-        <version>${sisuVersion}</version>
+        <version>${version.sisu-maven-plugin}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.plexus</artifactId>
-        <version>${sisuVersion}</version>
+        <version>${version.sisu-maven-plugin}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>${plexusUtilsVersion}</version>
+        <version>${version.plexus-utils}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-xml</artifactId>
-        <version>${plexusXmlVersion}</version>
+        <version>${version.plexus-xml}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -994,7 +994,7 @@ under the License.
         <plugin>
           <groupId>org.eclipse.sisu</groupId>
           <artifactId>sisu-maven-plugin</artifactId>
-          <version>${sisuVersion}</version>
+          <version>${version.sisu-maven-plugin}</version>
           <executions>
             <execution>
               <id>index-project</id>

--- a/src/site-docs/site.xml
+++ b/src/site-docs/site.xml
@@ -37,7 +37,7 @@ under the License.
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>${fluidoSkinVersion}</version>
+    <version>${version.maven-fluido-skin}</version>
   </skin>
 
   <edit>${project.scm.url}</edit>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -36,7 +36,7 @@ under the License.
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>${fluidoSkinVersion}</version>
+    <version>${version.maven-fluido-skin}</version>
   </skin>
 
   <edit>${project.scm.url}</edit>


### PR DESCRIPTION
finding while doing that:
- it happens that multiple components shared the same version: which artifactId should be promoted as the leading? or should we really let every artifactId have its own version defined separately?
- it even happens that the version is shared with a plugin (here it happens with sisu, this also can happen with plugin-tools vs plugin annotations)

some choices have been done in this PR
clearly, the "rule" cannot be a strict technical rule but more guidelines to be adapted to these edge cases