### PR TITLE
Drop banner name

### DIFF
--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -24,7 +24,6 @@ under the License.
 
 <!-- Start copy/paste of src/site/site.xml: inheritance does not work here because of src/site-docs hack -->
   <bannerLeft>
-    <name>${project.name}</name>
     <src>https://maven.apache.org/images/apache-maven-project.png</src>
     <href>https://www.apache.org/</href>
   </bannerLeft>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -23,7 +23,6 @@ under the License.
          xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.1 https://maven.apache.org/xsd/decoration-1.8.1.xsd">
 
   <bannerLeft>
-    <name>${project.name}</name>
     <src>https://maven.apache.org/images/apache-maven-project.png</src>
     <href>https://www.apache.org/</href>
   </bannerLeft>


### PR DESCRIPTION
We don't need a banner name since we use an image as a banner. Both we be displayed side-by-side with Maven Fluido Skin 2.0.0. If the banner image needs an alternative text, the new Site Model does provide such an attribute.

Addresses one of the issues from https://the-asf.slack.com/archives/C7Q9JB404/p1715479275966359