### PR TITLE
Upgrade plugin versions to migrate to Doxia 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -958,9 +958,18 @@ under the License.
     <!-- DO NOT UPGRADE to 4: incompatible with Maven 3 -->
     <version.plexus-xml>3.0.1</version.plexus-xml>
     <versions.junit5>5.10.3</versions.junit5>
-    <version.maven-fluido-skin>1.12.0</version.maven-fluido-skin>
     <version.maven-shared-resources>6</version.maven-shared-resources>
     <project.build.outputTimestamp>2024-07-04T20:44:45Z</project.build.outputTimestamp>
+
+    <!-- Upgrade to Doxia 2, to be removed with next parent pom upgrade -->
+    <version.maven-plugin-tools>3.15.0</version.maven-plugin-tools>
+    <version.maven-javadoc-plugin>3.10.1</version.maven-javadoc-plugin>
+    <version.maven-invoker-plugin>3.8.1</version.maven-invoker-plugin>
+    <version.maven-help-plugin>3.5.1</version.maven-help-plugin>
+    <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
+    <version.maven-fluido-skin>2.0.0</version.maven-fluido-skin>
+    <surefire.version>3.5.1</surefire.version>
+    <version.maven-project-info-reports-plugin>3.8.0</version.maven-project-info-reports-plugin>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -963,13 +963,14 @@ under the License.
 
     <!-- Upgrade to Doxia 2, to be removed with next parent pom upgrade -->
     <version.maven-plugin-tools>3.15.0</version.maven-plugin-tools>
-    <version.maven-javadoc-plugin>3.10.1</version.maven-javadoc-plugin>
+    <version.maven-javadoc-plugin>3.11.1</version.maven-javadoc-plugin>
     <version.maven-invoker-plugin>3.8.1</version.maven-invoker-plugin>
     <version.maven-help-plugin>3.5.1</version.maven-help-plugin>
     <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
     <version.maven-fluido-skin>2.0.0</version.maven-fluido-skin>
-    <surefire.version>3.5.1</surefire.version>
+    <surefire.version>3.5.2</surefire.version>
     <version.maven-project-info-reports-plugin>3.8.0</version.maven-project-info-reports-plugin>
+    <version.maven-plugin-tools>3.15.0</version.maven-plugin-tools>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Collect plugin upgrades to migrate to Doxia 2 stack.
We could first try to move our Maven projects then later wider for full ASF.