### PR TITLE
Introduce property maven.site.path.suffix to allow override site path

### DIFF
--- a/docs/src/site/apt/index.apt.vm
+++ b/docs/src/site/apt/index.apt.vm
@@ -71,19 +71,27 @@ mvn -Preporting site
 
     This POM prepares site publication to {{{/developers/website/index.html}Apache Maven's site svnpubsub}}.
 
+    There are defined <<<maven.site.path.suffix>>> properties in parent POM, as:
+
++-----+
+  <properties>
+    <maven.site.path.suffix>LATEST</maven.site.path.suffix>
+  </properties>
++-----+
+
+    Inherited project can change it in order to publish site in other path, like as:
+
++-----+
+  <properties>
+    <maven.site.path.suffix>LATEST-4.x</maven.site.path.suffix>
+  </properties>
++-----+
+
     There are defined <<<maven.site.path>>> properties in parent POM for each supported component type, as:
 
 +-----+
   <properties>
-    <maven.site.path>xxx-archives/\${project.artifactId}-LATEST</maven.site.path>
-  </properties>
-+-----+
-
-    For maven-extensions, maven-plugins and maven-shared-components which target Maven 4.x there are properties in parent POM:
-
-+-----+
-  <properties>
-    <maven4x.site.path>xxx-archives/\${project.artifactId}-LATEST-4.x</maven4x.site.path>
+    <maven.site.path>xxx-archives/\${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
   </properties>
 +-----+
 
@@ -96,14 +104,6 @@ mvn -Preporting site
       <url>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/components/${maven.site.path}</url>
     </site>
   </distributionManagement>
-+-----+
-
-    NOTE: For Maven 4.x publishing we need to override property <<<maven.site.path>>> by <<<maven4x.site.path>>>:
-
-+-----+
-  <properties>
-    <maven.site.path>${maven4x.site.path}</maven.site.path>
-  </properties>
 +-----+
 
     Once this is configured, the site can be published with:

--- a/doxia-tools/pom.xml
+++ b/doxia-tools/pom.xml
@@ -53,7 +53,7 @@ under the License.
 
   <properties>
     <projectVersion>${project.version}</projectVersion>
-    <maven.site.path>doxia-tools-archives/${project.artifactId}-LATEST</maven.site.path>
+    <maven.site.path>doxia-tools-archives/${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
   </properties>
 
   <build>

--- a/maven-extensions/pom.xml
+++ b/maven-extensions/pom.xml
@@ -42,8 +42,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <maven.site.path>extensions-archives/${project.artifactId}-LATEST</maven.site.path>
-    <maven4x.site.path>extensions-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
+    <maven.site.path>extensions-archives/${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
   </properties>
 
   <build>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -47,8 +47,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <maven.site.path>plugins-archives/${project.artifactId}-LATEST</maven.site.path>
-    <maven4x.site.path>plugins-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
+    <maven.site.path>plugins-archives/${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
     <enforce.dependency.declarations>false</enforce.dependency.declarations>
   </properties>
 

--- a/maven-shared-components/pom.xml
+++ b/maven-shared-components/pom.xml
@@ -50,8 +50,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <maven.site.path>shared-archives/${project.artifactId}-LATEST</maven.site.path>
-    <maven4x.site.path>shared-archives/${project.artifactId}-LATEST-4.x</maven4x.site.path>
+    <maven.site.path>shared-archives/${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
   </properties>
 
   <build>

--- a/maven-skins/pom.xml
+++ b/maven-skins/pom.xml
@@ -51,7 +51,7 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <maven.site.path>skins-archives/${project.artifactId}-LATEST</maven.site.path>
+    <maven.site.path>skins-archives/${project.artifactId}-${maven.site.path.suffix}</maven.site.path>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -962,6 +962,7 @@ under the License.
     <maven.site.cache>${user.home}/maven-sites</maven.site.cache>
     <!-- to be overridden -->
     <maven.site.path>../..</maven.site.path>
+    <maven.site.path.suffix>LATEST</maven.site.path.suffix>
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
     <version.sisu-maven-plugin>0.9.0.M3</version.sisu-maven-plugin>
     <version.plexus-utils>4.0.2</version.plexus-utils>


### PR DESCRIPTION
It will be easier to have a possibility to only change the LATEST item in site path instead of having dedicated for 4.x version.

Will suppress:
 - 46eba0f51da7c69fc4aea195cb28f6bd6d83c7f6 #231
 - 5c825483aaf44a20c0fbb5d10d4a9e5984ccb1d0 #233