### PR TITLE
update instructions to edit KEYS in Git

### DIFF
--- a/KEYS
+++ b/KEYS
@@ -1,10 +1,10 @@
-Edit this file in SVN at https://svn.apache.org/repos/asf/maven/project/KEYS
+Edit this file in https://github.com/apache/maven-parent/
 
 Then publish to download area /dist/maven/KEYS by
 
 svn co https://dist.apache.org/repos/dist/release/maven dist-maven
 cd dist-maven
-svn cat https://svn.apache.org/repos/asf/maven/project/KEYS > KEYS
+curl https://raw.githubusercontent.com/apache/maven-parent/refs/heads/master/KEYS > KEYS
 
 then commit.
 Download area publication is a PMC activity. If you are not a PMC member


### PR DESCRIPTION
KEYS files history was imported from svn in #240 

now we can have committers edit in Git like they do with any other committer content

and PMC members publish to dist area https://dlcdn.apache.org/maven/ (through svn https://dist.apache.org/repos/dist/release/maven)

This workflow is easier to follow (and even understand because edit in Git and publish in svn creates less confusion between the edit and publish urls)