### PR TITLE
Remove link to jira from issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -24,7 +24,3 @@ contact_links:
   - name: Project Mailing Lists
     url: https://maven.apache.org/mailing-lists.html
     about: Please ask a question or discuss here
-
-  - name: Old JIRA Issues
-    url: https://issues.apache.org/jira/projects/MPOM
-    about: Please search old JIRA issues


### PR DESCRIPTION
As we have migrated issues we can remove reference to jira