### PR TITLE
Use a standard tag template for releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,4 +20,4 @@
 _extends: maven-gh-actions-shared
 version-template: '$MAJOR'
 name-template: '$NEXT_MAJOR_VERSION'
-tag-template: 'v$NEXT_MAJOR_VERSION'
+tag-template: 'maven-parent-$NEXT_MAJOR_VERSION'

--- a/pom.xml
+++ b/pom.xml
@@ -1120,13 +1120,6 @@ under the License.</licenseText>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <configuration>
-            <tagNameFormat>v@{project.version}</tagNameFormat>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-toolchains-plugin</artifactId>
           <version>3.2.0</version>
         </plugin>


### PR DESCRIPTION
This revert commit: 23aaceb2a85669cd3bfbfd7380691ea1e2f0221a

https://github.com/apache/maven-parent/pull/455

And discussion: https://lists.apache.org/thread/f1n9moo9th1dn94z848xrqqyrlj8y7hf