### PR TITLE
Use spotless / palantirJavaFormat - 2.56.0 for all JDKs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -975,6 +975,9 @@ under the License.
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
     <version.sisu-maven-plugin>0.9.0.M4</version.sisu-maven-plugin>
     <version.plexus-utils>4.0.2</version.plexus-utils>
+    <version.spotless-maven-plugin>2.44.5</version.spotless-maven-plugin>
+    <!-- we use version 2.56.0 due to: https://github.com/palantir/palantir-java-format/issues/1320 -->
+    <version.palantirJavaFormat>2.56.0</version.palantirJavaFormat>
     <!-- DO NOT UPGRADE to 4: incompatible with Maven 3 -->
     <version.plexus-xml>3.0.1</version.plexus-xml>
     <versions.junit5>5.13.1</versions.junit5>
@@ -1208,12 +1211,16 @@ under the License.</licenseText>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
-          <version>2.44.5</version>
+          <version>${version.spotless-maven-plugin}</version>
           <configuration>
             <java>
               <!-- orders of used formatters are important MPOM-376 -->
               <!-- eg. palantir override importOrder, so should be first -->
-              <palantirJavaFormat />
+              <palantirJavaFormat>
+                <!-- Declare version so that spotless does not choose a version based on JDK version -->
+                <!-- https://github.com/diffplug/spotless/issues/2503#issuecomment-2953146277 -->
+                <version>${version.palantirJavaFormat}</version>
+              </palantirJavaFormat>
               <removeUnusedImports />
               <importOrder>
                 <file>config/maven-eclipse-importorder.txt</file>


### PR DESCRIPTION
Spotless start using palantir-java-format 2.57.0 on Java 21 - on older jdks different versions are used.

It causes a different code format depends on using JDK

references:
 - https://github.com/diffplug/spotless/pull/2447
 - https://github.com/diffplug/spotless/issues/2503
 - https://github.com/palantir/palantir-java-format/issues/1320

As issue - https://github.com/diffplug/spotless/issues/2503 was closed, reverting spotless plugin to an older version is not a resolution.