### PR TITLE
Use spotless on JDK 11 - 24 only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1348,7 +1348,8 @@ under the License.</licenseText>
     <profile>
       <id>java11+</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <!-- TODO check support for JDK 25 after palantirJavaFormat upgraded -->
+        <jdk>[11,25)</jdk>
       </activation>
       <build>
         <!--- newer versions of plugins requires JDK 11 -->


### PR DESCRIPTION
As a workaround due to lack of support for JDK 25 in palantirJavaFormat we will use spotless only on JDK 11 - 24

references:
 - https://github.com/apache/maven-parent/pull/477
 - https://github.com/palantir/palantir-java-format/pull/1305