### PR TITLE
Always render a GitHub ribbon on the right-hand side

### DIFF
--- a/maven-plugins/src/site/site.xml
+++ b/maven-plugins/src/site/site.xml
@@ -21,6 +21,16 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
+  <custom>
+    <fluidoSkin>
+      <gitHub>
+        <projectId>apache/${project.artifactId}</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>gray</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+
   <body>
     <breadcrumbs>
       <item name="Plugins" href="https://maven.apache.org/plugins/index.html" />


### PR DESCRIPTION
The GH project id is derived by default from the artifactId (but can be overwritten).

This closes #494

see for example https://maven.apache.org/plugins-archives/maven-clean-plugin-LATEST/