### PR TITLE
Render a GitHub ribbon on all sites

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -66,6 +66,8 @@ under the License.
     <maven.site.path>pom-archives/maven-LATEST</maven.site.path>
     <rat.skip>true</rat.skip>
 
+    <maven.site.gitHubProjectId>maven-parent</maven.site.gitHubProjectId>
+
     <!-- modules with documentation not need to install and deploy -->
     <maven.install.skip>true</maven.install.skip>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/docs/src/site/apt/index.apt.vm
+++ b/docs/src/site/apt/index.apt.vm
@@ -118,6 +118,15 @@ mvn scm-publish:publish-scm
 
 * History
 
+** 46
+
+  A <<GitHub ribbon>> has been added to the generated site to provide a direct link to the project's GitHub repository.
+
+  A new configuration property <<<maven.site.gitHubProjectId>>> has been introduced.
+  By default, this property is set to <<<$\{project.artifactId\}>>>, is used to resolve the <<GitHub>> repository URL for the ribbon link.
+
+** 38
+
     As of version 38, this POM sets the Java source and target versions to 1.8. Thus, as any plugin (or other component)
     moved to version 38+ of this POM, it moves to requiring Java 1.8 (was Java 1.5 since version 21, Java 1.6 since
     version 27, and Java 1.7 since version 34).

--- a/maven-plugins/src/site/site.xml
+++ b/maven-plugins/src/site/site.xml
@@ -21,16 +21,6 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
-  <custom>
-    <fluidoSkin>
-      <gitHub>
-        <projectId>apache/${project.artifactId}</projectId>
-        <ribbonOrientation>right</ribbonOrientation>
-        <ribbonColor>gray</ribbonColor>
-      </gitHub>
-    </fluidoSkin>
-  </custom>
-
   <body>
     <breadcrumbs>
       <item name="Plugins" href="https://maven.apache.org/plugins/index.html" />

--- a/pom.xml
+++ b/pom.xml
@@ -971,6 +971,8 @@ under the License.
     <!-- to be overridden -->
     <maven.site.path>../..</maven.site.path>
     <maven.site.path.suffix>LATEST</maven.site.path.suffix>
+    <!-- used by fluido Skin GitHUb ribbon -->
+    <maven.site.gitHubProjectId>${project.artifactId}</maven.site.gitHubProjectId>
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
     <version.sisu-maven-plugin>0.9.0.M4</version.sisu-maven-plugin>
     <version.plexus-utils>4.0.2</version.plexus-utils>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -50,6 +50,11 @@ under the License.
     </matomo>
     <fluidoSkin>
       <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+      <gitHub>
+        <projectId>apache/${maven.site.gitHubProjectId}</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>gray</ribbonColor>
+      </gitHub>
     </fluidoSkin>
   </custom>
 


### PR DESCRIPTION
firsst pass done for plugins only:
 - #494
 - #495

this PR is about extending to all projects, not only plugins
require introduction of property ` maven.site.gitHubProjectId` for multi-module builds