### PR TITLE
Bump parent version to 38-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>37</version>
+    <version>38-SNAPSHOT</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Why:
- Prepare for the next development iteration with updated parent version.