### PR TITLE
Simplify docs configuration

### DIFF
--- a/docs/maven-extensions/src/site/site.xml
+++ b/docs/maven-extensions/src/site/site.xml
@@ -21,19 +21,13 @@ under the License.
 
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+
+  <!-- we need to provide url for edit as scm in docs point to root -->
+  <edit>https://github.com/apache/maven-parent/tree/${project.scm.tag}/docs/maven-extensions</edit>
+
   <body>
     <breadcrumbs>
-      <item name="Maven" href="https://maven.apache.org/pom/maven/index.html" />
       <item name="Extensions" href="https://maven.apache.org/pom/maven/maven-extensions/index.html" />
     </breadcrumbs>
-
-    <menu name="Maven Parent POMs">
-      <item name="Maven" href="../index.html" />
-      <item name="Plugins" href="../maven-plugins/index.html" />
-      <item name="Extensions" href="index.html" />
-      <item name="Shared Components" href="../maven-shared-components/index.html" />
-      <item name="Skins" href="../maven-skins/index.html" />
-    </menu>
-
   </body>
 </site>

--- a/docs/maven-plugins/src/site/site.xml
+++ b/docs/maven-plugins/src/site/site.xml
@@ -22,19 +22,12 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
+  <!-- we need to provide url for edit as scm in docs point to root -->
+  <edit>https://github.com/apache/maven-parent/tree/${project.scm.tag}/docs/maven-plugins</edit>
+
   <body>
     <breadcrumbs>
-      <item name="Maven" href="https://maven.apache.org/pom/maven/index.html" />
       <item name="Plugins" href="https://maven.apache.org/pom/maven/maven-plugins/index.html" />
     </breadcrumbs>
-
-    <menu name="Maven Parent POMs">
-      <item name="Maven" href="../index.html" />
-      <item name="Plugins" href="index.html" />
-      <item name="Extensions" href="../maven-extensions/index.html" />
-      <item name="Shared Components" href="../maven-shared-components/index.html" />
-      <item name="Skins" href="../maven-skins/index.html" />
-    </menu>
-
   </body>
 </site>

--- a/docs/maven-shared-components/src/site/site.xml
+++ b/docs/maven-shared-components/src/site/site.xml
@@ -22,19 +22,12 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
+  <!-- we need to provide url for edit as scm in docs point to root -->
+  <edit>https://github.com/apache/maven-parent/tree/${project.scm.tag}/docs/maven-shared-components</edit>
+
   <body>
     <breadcrumbs>
-      <item name="Maven" href="https://maven.apache.org/pom/maven/index.html" />
       <item name="Shared Components" href="https://maven.apache.org/pom/maven/maven-shared-components/index.html" />
     </breadcrumbs>
-
-    <menu name="Maven Parent POMs">
-      <item name="Maven" href="../index.html" />
-      <item name="Plugins" href="../maven-plugins/index.html" />
-      <item name="Extensions" href="../maven-extensions/index.html" />
-      <item name="Shared Components" href="index.html" />
-      <item name="Skins" href="../maven-skins/index.html" />
-    </menu>
-
   </body>
 </site>

--- a/docs/maven-skins/src/site/site.xml
+++ b/docs/maven-skins/src/site/site.xml
@@ -22,19 +22,12 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
+  <!-- we need to provide url for edit as scm in docs point to root -->
+  <edit>https://github.com/apache/maven-parent/tree/${project.scm.tag}/docs/maven-skins</edit>
+
   <body>
     <breadcrumbs>
-      <item name="Maven" href="https://maven.apache.org/pom/maven/index.html" />
       <item name="Skins" href="https://maven.apache.org/pom/maven/maven-skins/index.html" />
     </breadcrumbs>
-
-    <menu name="Maven Parent POMs">
-      <item name="Maven" href="../index.html" />
-      <item name="Plugins" href="../maven-plugins/index.html" />
-      <item name="Extensions" href="../maven-extensions/index.html" />
-      <item name="Shared Components" href="../maven-shared-components/index.html" />
-      <item name="Skins" href="index.html" />
-    </menu>
-
   </body>
 </site>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -42,7 +42,7 @@ under the License.
 
   <scm>
     <tag>master</tag>
-    <url>https://github.com/apache/maven-parent/tree/${project.scm.tag}/</url>
+    <url>https://github.com/apache/maven-parent/tree/${project.scm.tag}</url>
   </scm>
 
   <issueManagement>

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -22,48 +22,12 @@ under the License.
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
 
-<!-- Start copy/paste of src/site/site.xml: inheritance does not work here because of src/site-docs hack -->
-  <bannerLeft href="https://www.apache.org/">
-    <image src="https://maven.apache.org/images/apache-maven-project.png"/>
-  </bannerLeft>
-
-  <bannerRight href="https://maven.apache.org/">
-    <image src="https://maven.apache.org/images/maven-logo-black-on-white.png"/>
-  </bannerRight>
-
-  <skin>
-    <groupId>org.apache.maven.skins</groupId>
-    <artifactId>maven-fluido-skin</artifactId>
-    <version>${version.maven-fluido-skin}</version>
-  </skin>
-
-  <edit>${project.scm.url}</edit>
-
-  <custom>
-    <matomo>
-      <siteId>3</siteId>
-      <url>https://analytics.apache.org/</url>
-      <options>
-        <disableCookies/>
-        <trackPageView/>
-        <enableLinkTracking/>
-      </options>
-    </matomo>
-    <fluidoSkin>
-      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
-      <anchorJs />
-    </fluidoSkin>
-  </custom>
-
-  <publishDate position="right" />
-  <version position="right" />
-<!-- End copy/paste of src/site/site.xml -->
+  <!-- we need to provide url for edit as scm in docs point to root -->
+  <edit>https://github.com/apache/maven-parent/tree/${project.scm.tag}/docs</edit>
 
   <body>
 
     <breadcrumbs>
-      <item name="Apache" href="https://www.apache.org/" />
-      <item name="Maven"  href="https://maven.apache.org/index.html" />
       <item name="Parent POMs" href="https://maven.apache.org/pom/index.html" />
       <item name="Maven"  href="https://maven.apache.org/pom/maven/index.html" />
     </breadcrumbs>
@@ -75,7 +39,7 @@ under the License.
       <item name="Download" href="download.html"/>
     </menu>
 
-    <menu name="Maven Parent POMs">
+    <menu name="Maven Parent POMs" inherit="top">
       <item name="Maven" href="index.html"/>
       <item name="Plugins" href="maven-plugins/index.html"/>
       <item name="Extensions" href="maven-extensions/index.html"/>


### PR DESCRIPTION
Currently, we have a standard parent in docs modules, so we do not need to override already defined items