### PR TITLE
Add configuration for rerunning failing integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -969,6 +969,7 @@ under the License.
     <!-- to be overridden -->
     <maven.site.path>../..</maven.site.path>
     <maven.site.path.suffix>LATEST</maven.site.path.suffix>
+    <invoker.rerunFailingTestsCount>1</invoker.rerunFailingTestsCount>
     <invoker.streamLogsOnFailures>true</invoker.streamLogsOnFailures>
     <version.sisu-maven-plugin>1.0.0</version.sisu-maven-plugin>
     <version.plexus-utils>4.0.3</version.plexus-utils>
@@ -1177,6 +1178,7 @@ under the License.</licenseText>
             <postBuildHookScript>verify</postBuildHookScript>
             <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
             <settingsFile>src/it/settings.xml</settingsFile>
+            <rerunFailingTestsCount>${invoker.rerunFailingTestsCount}</rerunFailingTestsCount>
             <streamLogsOnFailures>${invoker.streamLogsOnFailures}</streamLogsOnFailures>
             <pomIncludes>
               <pomInclude>*/pom.xml</pomInclude>


### PR DESCRIPTION
Why:
 - on CI we have many times problems with connection timeout
 - rerun failed tests can make less maintenance to manually rerun