### PR TITLE
Set custom output name for CycloneDX BOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1403,6 +1403,9 @@ under the License.</licenseText>
                   <goal>makeAggregateBom</goal>
                 </goals>
                 <phase>package</phase>
+                <configuration>
+                  <outputName>${project.artifactId}-${project.version}-cyclonedx</outputName>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Allow to easier use output file do deploy to ATR.

Deployed artifact is not changed.