### PR TITLE
Exclude dev-tooling dotfiles from RAT check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1282,6 +1282,11 @@ under the License.</licenseText>
               <exclude>dependency-reduced-pom.xml</exclude>
               <!-- GitHub Support -->
               <exclude>.asf.yaml</exclude>
+              <!-- Developer tooling: version managers / direnv (local, not project source) -->
+              <exclude>.sdkmanrc</exclude>
+              <exclude>.tool-versions</exclude>
+              <exclude>.envrc</exclude>
+              <exclude>.mise.toml</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
## What & why

Dropping common developer-machine dotfiles into a checkout makes a local
`mvn verify` fail at `apache-rat-plugin:check` with *"Too many files with
unapproved license"*. These are not project source — they are local
conveniences from version managers and direnv:

- `.sdkmanrc` (SDKMAN!)
- `.tool-versions` (asdf)
- `.envrc` (direnv)
- `.mise.toml` (mise)

This adds them to the existing `apache-rat-plugin` `<excludes>` list, right
next to `.java-version`, which is already excluded for exactly the same
reason. `combine.children="append"` keeps RAT's built-in defaults intact.

## Why excludes (and not SPDX headers)

An alternative would be to add an `SPDX-License-Identifier` / ASF header to each
file. That doesn't fit here: these are third-party tool configuration formats,
not files we author, and carrying a per-file licence comment in every repo for
two lines of payload is exactly the boilerplate this change avoids. Excluding
them centrally in `maven-parent` mirrors how `.gitignore` / `.editorconfig`
(RAT built-in defaults) and `.java-version` are already handled.

## Verification

apache-rat-plugin `0.16.1` (the version pinned by `org.apache:apache:38`) on a
minimal project containing the four dotfiles:
- before: `BUILD FAILURE`, 4 unapproved files;
- after (with these excludes): `BUILD SUCCESS`.

Also verified end-to-end against a real `apache/maven` checkout using a locally
built `maven-parent` carrying this change: `rat:check` no longer flags the
dotfiles. CI is unaffected (clean checkouts don't carry these files); this
purely lowers local-developer friction.

---

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Run `mvn verify` to make sure basic checks pass.
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
