### PR TITLE
Add Gerd Aschemann to committer list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,15 @@ under the License.
       <timezone>Europe/Berlin</timezone>
     </developer>
     <developer>
+      <id>ascheman</id>
+      <name>Gerd Aschemann</name>
+      <email>ascheman@apache.org</email>
+      <roles>
+        <role>Committer</role>
+      </roles>
+      <timezone>Europe/Berlin</timezone>
+    </developer>
+    <developer>
       <id>bdemers</id>
       <name>Brian Demers</name>
       <email>bdemers@apache.org</email>


### PR DESCRIPTION
Adds myself (Apache id `ascheman`) to the committer list in `pom.xml`, inserted alphabetically in the Committers section.

Following the established convention for new committers (e.g. #230).