### PR TITLE
resolve parent POM from r.a.o

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <activeProfiles>
+    <activeProfile>rao</activeProfile>
+  </activeProfiles>
+  <profiles>
+    <profile>
+      <id>rao</id>
+      <repositories>
+        <repository><!-- useful for releasing while voting on Apache parent POM -->
+          <id>repository.apache.org</id>
+          <url>https://repository.apache.org/content/repositories/staging/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+</settings>

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,5 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
     with:
+      # to be able to use staging Apache parent POM
+      maven-args: "-s .github/settings.xml"
       ff-site-goal: 'site'
       matrix-enabled: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 // jdk 21 is used for deploy artifacts
-asfMavenTlpStdBuild(jdks:['21'])
+asfMavenTlpStdBuild(jdks:['21'], mavenArgs:'-s .github/settings.xml')


### PR DESCRIPTION
give we do in general simultaneous vote on Apache parent and Maven parents, CI fails during the vote (Apache parent is not yet in Central)

use r.a.o to use staging Apache parent release to avoid this small during voting period